### PR TITLE
Proposing a task for easily opening guaranteed cells

### DIFF
--- a/TODO
+++ b/TODO
@@ -6,6 +6,7 @@ TODO:
  * new levels ...
  * flower / star shaped levels
  * option for only solvable games
+ * open surrounded cells when clicked to a number if all possible mines are already flagged.
 
  * do you have any idea ?
 


### PR DESCRIPTION
Most modern minesweeper games allow to open cells around the number when all its possible mines are already flagged.

For example: There is a number 3, which means there should be 3 mines around it. If you already places 3 flags around that number, all other cells around it should be without flags. In that case, when you click on this number, it would be great if all these cells becomes opened instead of clicking one-by-one on them.

If you misflagged a cell, it will be same as clicking on a mine (game over).
If you flagged more than the number (the number 3 in the example case) or less it will be ignored (do nothing).

This is only a proposal as I couldn't find issues list and place for reporting issues is not mentioned in the project.